### PR TITLE
register page tests

### DIFF
--- a/cypress/e2e/3-Register-page/1-filling.cy.js
+++ b/cypress/e2e/3-Register-page/1-filling.cy.js
@@ -1,0 +1,23 @@
+describe('Registration Form Test 1', () => {
+    it('should fill out the registration form and check the checkbox', () => {
+ 
+      cy.visit('/auth/register');
+
+      cy.get('[name="fullName"]').type('Maryna Vasylyk');
+      cy.get('[name="email"]').type('marynav@example.com');
+      cy.get('[name="password"]').type('password123');
+      cy.get('[name="rePass"]').type('password123');
+
+      cy.get('span.custom-checkbox').click();
+  
+      cy.get('[name="fullName"]').should('have.value', 'Maryna Vasylyk');
+      cy.get('[name="email"]').should('have.value', 'marynav@example.com');
+      cy.get('[name="password"]').should('have.value', 'password123');
+      cy.get('[name="rePass"]').should('have.value', 'password123');
+  
+      cy.get('.btn-disabled').should('not.exist');
+  
+      cy.contains('Register').click();
+    });
+  });
+  

--- a/cypress/e2e/3-Register-page/2-checking.cy.js
+++ b/cypress/e2e/3-Register-page/2-checking.cy.js
@@ -1,0 +1,19 @@
+describe('Registration Form Test 2', () => {
+    it('should check headers and labels in the registration form', () => {
+
+      cy.visit('/auth/register');
+
+      cy.get('h1.title').should('contain', 'Register');
+
+      cy.get('[for="input-name"]').should('contain', 'Full name:');
+      cy.get('[for="input-email"]').should('contain', 'Email address:');
+      cy.get('[for="input-password"]').should('contain', 'Password:');
+      cy.get('[for="input-re-password"]').should('contain', 'Repeat password:');
+    
+      cy.get('nb-checkbox[name="terms"] label').should('contain', 'Agree to Terms & Conditions');
+
+      cy.get('[data-name="github"]').should('exist');
+      cy.get('[data-name="facebook"]').should('exist');
+      cy.get('[data-name="twitter"]').should('exist');
+    });
+  });

--- a/cypress/e2e/3-Register-page/3-failing.cy.js
+++ b/cypress/e2e/3-Register-page/3-failing.cy.js
@@ -1,0 +1,21 @@
+describe('Registration Form Error Tests', () => {
+    it('should validate fields and display error messages', () => {
+      cy.visit('/auth/register');
+    
+      // Валідація поля Full name
+      cy.get('[name="fullName"]').type('...');
+      cy.get("body").click();
+      cy.get('p.caption.status-danger').should('contain', 'Full name should contains from 4 to 50 characters');
+
+      // Валідація поля Email address
+      cy.get('[name="email"]').type('33.22');
+      cy.get("body").click();
+      cy.get('p.caption.status-danger').should('contain', 'Email should be the real one!');
+
+      // Валідація поля Password
+      cy.get('[name="password"]').type('111');
+      cy.get("body").click();
+      cy.get('p.caption.status-danger').should('contain', 'Password should contain from 4 to 50 characters');
+    });
+  });
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "codelyzer": "^5.0.1",
         "conventional-changelog-cli": "^2.1.1",
         "cypress": "^13.3.3",
+        "cypress-xpath": "^2.0.1",
         "husky": "0.13.3",
         "npm-run-all": "4.0.2",
         "rimraf": "2.6.1",
@@ -7526,6 +7527,13 @@
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
+    },
+    "node_modules/cypress-xpath": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-xpath/-/cypress-xpath-2.0.1.tgz",
+      "integrity": "sha512-qMagjvinBppNJdMAkucWESP9aP4rDTs7c96m0vwMuZTVx3NqP2E3z/hkoRf8Ea9soL8yTvUuuyF1cg/Sb1Yhbg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true
     },
     "node_modules/cypress/node_modules/@types/node": {
       "version": "18.18.7",
@@ -29444,6 +29452,12 @@
           "dev": true
         }
       }
+    },
+    "cypress-xpath": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-xpath/-/cypress-xpath-2.0.1.tgz",
+      "integrity": "sha512-qMagjvinBppNJdMAkucWESP9aP4rDTs7c96m0vwMuZTVx3NqP2E3z/hkoRf8Ea9soL8yTvUuuyF1cg/Sb1Yhbg==",
+      "dev": true
     },
     "d": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "prepush": "npm run lint:ci",
     "release:changelog": "npm run conventional-changelog -- -p angular -i CHANGELOG.md -s",
     "cy:open": "cypress open",
-    "cy:run":"cypress run"
- },
+    "cy:run": "cypress run"
+  },
   "dependencies": {
     "@agm/core": "^1.1.0",
     "@angular/animations": "^8.0.0",
@@ -95,6 +95,7 @@
     "codelyzer": "^5.0.1",
     "conventional-changelog-cli": "^2.1.1",
     "cypress": "^13.3.3",
+    "cypress-xpath": "^2.0.1",
     "husky": "0.13.3",
     "npm-run-all": "4.0.2",
     "rimraf": "2.6.1",


### PR DESCRIPTION
Created 3 tests for page http://localhost:4200/auth/register:
1. Registration Form Test 1 - should fill out the registration form and check the checkbox
2. Registration Form Test 2 - should check headers and labels in the registration form
3. Registration Form Error Tests - should validate fields and display error messages

also instal Хpath, but not add it to support-commands.ts (have an issue here)
